### PR TITLE
Support application/jrd+json MIME type as Webfinger response.

### DIFF
--- a/lib/webfinger.js
+++ b/lib/webfinger.js
@@ -400,7 +400,7 @@ var httpsWebfinger = function(hostname, resource, rel, callback) {
         httpsOnly: true
     };
 
-    request(https, options, {"application/json": jrd}, callback);
+    request(https, options, {"application/json": jrd, "application/jrd+json": jrd}, callback);
 };
 
 var template = function(tmpl, address, parsers, httpsOnly, callback) {


### PR DESCRIPTION
In OpenID Connect Discovery, the mime type is consistently `application/jrd+json`.

http://openid.net/specs/openid-connect-discovery-1_0.html